### PR TITLE
Improved init-ansible-debian.sh script.

### DIFF
--- a/init-ansible-debian.sh
+++ b/init-ansible-debian.sh
@@ -8,6 +8,6 @@ echo 'Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/s
 
 adduser ansible --shell /bin/bash --disabled-password --gecos ""
 mkdir -p /home/ansible/.ssh/
-chown ansible .ssh/
-echo $INITIAL_AUTHORIZED_KEY >> /home/ansible/.ssh/authorized_keys
+chown ansible /home/ansible/.ssh/
+grep -q "$INITIAL_AUTHORIZED_KEY" /home/ansible/.ssh/authorized_keys || echo $INITIAL_AUTHORIZED_KEY >> /home/ansible/.ssh/authorized_keys
 echo 'ansible ALL=(ALL) NOPASSWD:ALL' | tee -a /etc/sudoers


### PR DESCRIPTION
Improved init-ansible-debian.sh script:

- Corrected path for "chown" command
- Will add the inital authorized SSH key to the authorized_keys file only if it doesn't already exists